### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/layertwo/pymumble/security/code-scanning/1](https://github.com/layertwo/pymumble/security/code-scanning/1)

To fix this issue, we should add a `permissions` block to the workflow, specifying the least privilege required: `contents: read`. This can be done either at the workflow root (affecting all jobs unless overridden) or specifically for the job named `test`. Since there is only one job, the simplest and most robust solution is to set the `permissions` block at the root level, directly beneath the `name` and above the `on:` block. This ensures the workflow does not receive excessive repository privileges, and will protect against privilege escalation through the default settings.

Required changes:
- Edit `.github/workflows/ci.yml`.
- Insert a line:  
  ```yaml
  permissions:
    contents: read
  ```
  directly after `name: CI` (line 1).

No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
